### PR TITLE
Disable proxy usage by default when scraping

### DIFF
--- a/scrape_reviews.py
+++ b/scrape_reviews.py
@@ -478,6 +478,10 @@ def scrape_reviews(
         max_pages: int = 20,
 ) -> List[Dict]:
         session = requests.Session()
+        allow_proxy_env = os.environ.get("SCRAPER_ALLOW_PROXY", "")
+        if allow_proxy_env.strip().lower() not in {"1", "true", "yes", "on"}:
+                session.trust_env = False
+                session.proxies = {}
         company_slug = normalize_company_to_slug(company)
 
         source_key = source.lower()


### PR DESCRIPTION
## Summary
- disable automatic use of environment proxies for scraping sessions to avoid proxy blocks when fetching review pages
- allow opting back into proxy usage via the `SCRAPER_ALLOW_PROXY` environment variable when needed

## Testing
- python3 scrape_reviews.py --help

------
https://chatgpt.com/codex/tasks/task_e_68d194f92204832cb02ef59836b8450c